### PR TITLE
fix: publish transpiled code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ node_js:
 install:
   - yarn
 script:
+  - yarn build
   - yarn test
 after_success:
   - yarn semantic-release

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jest-runner-tsc",
   "version": "0.0.0-development",
   "description": "A Jest Runner for the TypeScript compiler",
-  "main": "src",
+  "main": "dist",
   "engines": {
     "node": ">=6"
   },


### PR DESCRIPTION
I'm not sure why I wasn't doing this before, but #7 switched some `require`s to `import`s so this may actually be required now.

@SimenB should Jest runners be pre-transpiled? I guess they'd work by being transpiled at runtime, but that assumes that that Jest is configured in a particular way.