### PR TITLE
fix: correct reporting interface

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -5,6 +5,8 @@ extends:
 env:
   es6: true
   node: true
+parserOptions:
+  ecmaVersion: 2018
 overrides:
 - files: "src/**/*.js"
   parserOptions:

--- a/src/runTsc.js
+++ b/src/runTsc.js
@@ -2,6 +2,7 @@ import path from 'path';
 import { codeFrameColumns as codeFrame } from '@babel/code-frame';
 import ts from 'typescript';
 import fs from 'fs';
+import { pass, fail } from 'create-jest-runner';
 
 const appendCodeFrame = ({ filePath, errorMessage, location }) => {
   if (typeof location === 'undefined') {
@@ -13,73 +14,46 @@ const appendCodeFrame = ({ filePath, errorMessage, location }) => {
   })}`;
 };
 
-const convertErrors = ({ start, end, errors, testPath }) => ({
-  console: null,
-  failureMessage: errors.map(appendCodeFrame).join('\n\n'),
-  numFailingTests: errors.length,
-  numPassingTests: errors.length ? 0 : 1,
-  numPendingTests: 0,
-  perfStats: {
-    end,
+const runTsc = ({ testPath, config: jestConfig }) => {
+  const start = Date.now();
+  const configPath = path.resolve(jestConfig.rootDir, 'tsconfig.json');
+  const configContents = fs.readFileSync(configPath).toString();
+  const { config, error } = ts.parseConfigFileTextToJson(
+    configPath,
+    configContents
+  );
+
+  const baseObj = {
     start,
-  },
-  snapshot: {
-    added: 0,
-    fileDeleted: false,
-    matched: 0,
-    unchecked: 0,
-    unmatched: 0,
-    updated: 0,
-  },
-  sourceMaps: {},
-  testExecError: null,
-  testFilePath: testPath,
-  testResults: (errors.length ? errors : [{ filePath: testPath }]).map(
-    error => ({
-      ancestorTitles: [],
-      duration: end - start,
-      failureMessages: [error.errorMessage],
-      fullName: error.filePath,
-      numPassingAsserts: error.errorMessage ? 1 : 0,
-      status: error.errorMessage ? 'failed' : 'passed',
-      title: 'tsc',
-    })
-  ),
-});
+    title: 'tsc',
+    test: { path: testPath },
+  };
 
-const runTsc = ({ testPath, config: jestConfig }, workerCallback) => {
-  try {
-    const configPath = path.resolve(jestConfig.rootDir, 'tsconfig.json');
-    const configContents = fs.readFileSync(configPath).toString();
-    const { config, error } = ts.parseConfigFileTextToJson(
-      configPath,
-      configContents
-    );
+  if (error) {
+    return fail({
+      ...baseObj,
+      end: Date.now(),
+      errorMessage: error,
+    });
+  }
 
-    if (error) {
-      return {
-        errorMessage: error,
-        filePath: testPath,
-      };
-    }
+  const settings = ts.convertCompilerOptionsFromJson(
+    config['compilerOptions'] || {},
+    process.cwd()
+  );
 
-    const settings = ts.convertCompilerOptionsFromJson(
-      config['compilerOptions'] || {},
-      process.cwd()
-    );
+  const options = Object.assign({}, { noEmit: true }, settings.options);
 
-    const options = Object.assign({}, { noEmit: true }, settings.options);
+  const program = ts.createProgram([testPath], options);
 
-    const start = Date.now();
-    const program = ts.createProgram([testPath], options);
+  const emitResult = program.emit();
 
-    const emitResult = program.emit();
+  const allDiagnostics = ts
+    .getPreEmitDiagnostics(program)
+    .concat(emitResult.diagnostics);
 
-    const allDiagnostics = ts
-      .getPreEmitDiagnostics(program)
-      .concat(emitResult.diagnostics);
-
-    const errors = allDiagnostics.map(diagnostic => {
+  const errors = allDiagnostics
+    .map(diagnostic => {
       if (diagnostic.file) {
         const {
           line: lineStart,
@@ -122,13 +96,20 @@ const runTsc = ({ testPath, config: jestConfig }, workerCallback) => {
           filePath: testPath,
         };
       }
-    });
+    })
+    .map(appendCodeFrame);
 
-    const end = Date.now();
-    workerCallback(null, convertErrors({ start, end, errors, testPath }));
-  } catch (e) {
-    workerCallback(e);
+  const end = Date.now();
+
+  if (errors.length === 0) {
+    return pass({ ...baseObj, end });
   }
+
+  return fail({
+    ...baseObj,
+    errorMessage: errors.join('\n\n'),
+    end,
+  });
 };
 
 module.exports = runTsc;


### PR DESCRIPTION
Hah, I trusted the "tests" too much. The callback is not used in create-jest-runner (it's promise-based). Now I've actually tested it in a project.

Recommended to look at the diff with whitespace turned off.

@rogeliog we should have a test helpers package for runners, or at the very least some sort of cookbook