### PR TITLE
Fixed slow builds

### DIFF
--- a/src/runTsc.js
+++ b/src/runTsc.js
@@ -42,17 +42,16 @@ const runTsc = ({ testPath, config: jestConfig }) => {
     process.cwd()
   );
 
-  const options = Object.assign({}, { noEmit: true }, settings.options);
+  const options = {
+    compilerOptions: {
+      noEmit: true,
+      ...settings.options,
+    },
+  };
 
-  const program = ts.createProgram([testPath], options);
+  const transpileOutput = ts.transpileModule(testPath, options);
 
-  const emitResult = program.emit();
-
-  const allDiagnostics = ts
-    .getPreEmitDiagnostics(program)
-    .concat(emitResult.diagnostics);
-
-  const errors = allDiagnostics
+  const errors = transpileOutput.diagnostics
     .map(diagnostic => {
       if (diagnostic.file) {
         const {


### PR DESCRIPTION
Using `transpileModule` instead of `createProgram` fixed the problem with slow builds on a bigger codebase. 
Was testing on a set of 660 ts/tsx files.
Based on a documentation from [TS wiki](https://github.com/Microsoft/TypeScript/wiki/Using-the-Compiler-API#transpiling-a-single-file).

## Performance results

> Test Suites: 660 passed, 660 total
> Tests:       660 passed, 660 total
> Snapshots:   0 total

### With this PR

> Time:        3.329s, estimated 12s
> Ran all test suites.
> ✨  Done in **4.77s**.

### Current v1.4.0

Around **5 min**

### Actual `tsc --noEmit`

Around **12.59s**

