### PR TITLE
fix: prevent duplicate errors

### DIFF
--- a/src/runTsc.js
+++ b/src/runTsc.js
@@ -50,7 +50,8 @@ const runTsc = ({ testPath, config: jestConfig }) => {
 
   const allDiagnostics = ts
     .getPreEmitDiagnostics(program)
-    .concat(emitResult.diagnostics);
+    .concat(emitResult.diagnostics)
+    .filter(diagnostic => diagnostic.file.fileName === testPath);
 
   const errors = allDiagnostics
     .map(diagnostic => {


### PR DESCRIPTION
Fixes #17

This works by filtering any errors that were emitted from a file different to the current file being tested.

I couldn't work out a good way to test this so if this requires tests it would be great if you could point me in the write direction on it.