### PR TITLE
Add ability to define tsconfig.json path

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 npm install --save-dev jest-runner-tsc
 ```
 
-## configure
+## usage
 
 Jest configuration:
 
@@ -28,6 +28,30 @@ module.exports = {
   testMatch: ['<rootDir>/**/*.ts'],
 };
 ```
+
+## options
+
+This project uses [cosmiconfig](https://github.com/davidtheclark/cosmiconfig), so you can provide config via:
+
+- a `jest-runner-tsc` property in your package.json
+- a `jest-runner-tsc.config.js` JS file
+- a `.jest-runner-tscrc` JSON file
+
+### Example in package.json
+
+```json
+{
+  "jest-runner-tsc": {
+    "tsconfigPath": "./tsconfig.types.json"
+  }
+}
+```
+
+### `tsconfigPath`
+
+Default: `./tsconfig.json`
+
+A relative path to your `tsconfig.json` file.
 
 ## run
 

--- a/package.json
+++ b/package.json
@@ -34,11 +34,14 @@
   },
   "dependencies": {
     "@babel/code-frame": "^7.0.0",
+    "cosmiconfig": "^5.2.1",
     "create-jest-runner": "~0.4.1"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/azz/jest-runner-tsc.git"
   },
-  "files": ["/dist"]
+  "files": [
+    "/dist"
+  ]
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,17 @@
 import { createJestRunner } from 'create-jest-runner';
+import cosmiconfig from 'cosmiconfig';
 
-module.exports = createJestRunner(require.resolve('./runTsc'));
+const explorer = cosmiconfig('jest-runner-tsc');
+
+const getExtraOptions = () => {
+  const searchedFor = explorer.searchSync();
+  if (!searchedFor || typeof searchedFor.config === 'undefined') {
+    return {};
+  }
+
+  return searchedFor.config;
+};
+
+module.exports = createJestRunner(require.resolve('./runTsc'), {
+  getExtraOptions,
+});

--- a/src/runTsc.js
+++ b/src/runTsc.js
@@ -14,9 +14,20 @@ const appendCodeFrame = ({ filePath, errorMessage, location }) => {
   })}`;
 };
 
-const runTsc = ({ testPath, config: jestConfig }) => {
+const runTsc = ({ testPath, config: jestConfig, extraOptions }) => {
   const start = Date.now();
-  const configPath = path.resolve(jestConfig.rootDir, 'tsconfig.json');
+
+  const configPath =
+    typeof extraOptions.tsconfigPath === 'string'
+      ? path.resolve(extraOptions.tsconfigPath)
+      : path.resolve(jestConfig.rootDir, 'tsconfig.json');
+
+  if (!fs.existsSync(configPath)) {
+    throw new Error(
+      'Cannot find tsconfig file. Either create one in the root of your project or define a custom path via the `tsconfigPath` option.'
+    );
+  }
+
   const configContents = fs.readFileSync(configPath).toString();
   const { config, error } = ts.parseConfigFileTextToJson(
     configPath,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1412,6 +1412,16 @@ cosmiconfig@^5.0.0:
     js-yaml "^3.9.0"
     parse-json "^4.0.0"
 
+cosmiconfig@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
+  integrity sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==
+  dependencies:
+    import-fresh "^2.0.0"
+    is-directory "^0.3.1"
+    js-yaml "^3.13.1"
+    parse-json "^4.0.0"
+
 create-jest-runner@^0.4.1, create-jest-runner@~0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/create-jest-runner/-/create-jest-runner-0.4.1.tgz#eeda15bc0f9dc622ef2de5a7fd9a0f1a2c2eb62d"
@@ -3285,6 +3295,14 @@ js-yaml@^3.12.0, js-yaml@^3.9.0:
   version "3.12.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.1.tgz#295c8632a18a23e054cf5c9d3cecafe678167600"
   integrity sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
+js-yaml@^3.13.1:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"


### PR DESCRIPTION
Closes #10 

This uses [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) so you can provide config via:

- a `jest-runner-tsc` property in your package.json
- a `jest-runner-tsc.config.js` JS file
- a `.jest-runner-tscrc` JSON file